### PR TITLE
The "data" directory has to be available for the webpage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM caddy:alpine AS webserver
 WORKDIR /app
 COPY . .
 
+RUN rm -rf /app/data && ln -s /var/www/html/meshmap/data /app/data
+
 RUN addgroup --system caddy && \
 adduser caddy --system -G caddy && \
 chown -R caddy:caddy /app


### PR DESCRIPTION
but the real data directory lives on a shared volume.
create a symlink inside the container to the shared "data" directory.
